### PR TITLE
Fix Examples

### DIFF
--- a/Examples/src/main/java/com/mapbox/vision/examples/ArActivity.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/ArActivity.java
@@ -83,11 +83,6 @@ public class ArActivity extends BaseActivity implements RouteListener, ProgressC
     private final Point ROUTE_DESTINATION = Point.fromLngLat(27.655637, 53.935712);
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
     protected void initViews() {
         setContentView(R.layout.activity_ar_navigation);
     }

--- a/Examples/src/main/java/com/mapbox/vision/examples/BaseActivity.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/BaseActivity.java
@@ -36,7 +36,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             Toast.makeText(this, text, Toast.LENGTH_LONG).show();
             VisionLogger.Companion.e(
                     "NotSupportedBoard",
-                    "Current board is {\"$board\"}, Supported Boards: [${enumValues<SupportedSnapdragonBoards>().joinToString { it.name }}]; System Info: [${SystemInfoUtils.obtainSystemInfo()}]"
+                    "Current board is " + board + ", Supported Boards: [ " + getSupportedBoardNames() + " ]; System Info: [ " + SystemInfoUtils.INSTANCE.obtainSystemInfo() + " ]"
             );
             finish();
             return;
@@ -49,6 +49,15 @@ public abstract class BaseActivity extends AppCompatActivity {
         } else {
             onPermissionsGranted();
         }
+    }
+
+    private String getSupportedBoardNames() {
+        StringBuilder sb = new StringBuilder();
+        for (SupportedSnapdragonBoards board : SupportedSnapdragonBoards.values()) {
+            sb.append(board.name());
+        }
+
+        return sb.toString();
     }
 
     protected boolean allPermissionsGranted() {

--- a/Examples/src/main/java/com/mapbox/vision/examples/BaseActivity.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/BaseActivity.java
@@ -1,0 +1,93 @@
+package com.mapbox.vision.examples;
+
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.text.Html;
+import android.text.Spanned;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import com.mapbox.vision.mobile.core.utils.SystemInfoUtils;
+import com.mapbox.vision.mobile.core.utils.snapdragon.SupportedSnapdragonBoards;
+import com.mapbox.vision.utils.VisionLogger;
+
+public abstract class BaseActivity extends AppCompatActivity {
+
+    private static final String PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE";
+    private static final int PERMISSIONS_REQUEST_CODE = 123;
+
+    protected abstract void onPermissionsGranted();
+
+    protected abstract void initViews();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String board = SystemInfoUtils.INSTANCE.getSnpeSupportedBoard();
+        if (!SupportedSnapdragonBoards.isBoardSupported(board)) {
+            Spanned text =
+                    Html.fromHtml("The device is not supported, you need <b>Snapdragon-powered</b> device with <b>OpenCL</b> support, more details at <b>https://www.mapbox.com/android-docs/vision/overview/</b>");
+            Toast.makeText(this, text, Toast.LENGTH_LONG).show();
+            VisionLogger.Companion.e(
+                    "NotSupportedBoard",
+                    "Current board is {\"$board\"}, Supported Boards: [${enumValues<SupportedSnapdragonBoards>().joinToString { it.name }}]; System Info: [${SystemInfoUtils.obtainSystemInfo()}]"
+            );
+            finish();
+            return;
+        }
+
+        initViews();
+
+        if (!allPermissionsGranted() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            requestPermissions(getRequiredPermissions(), PERMISSIONS_REQUEST_CODE);
+        } else {
+            onPermissionsGranted();
+        }
+    }
+
+    protected boolean allPermissionsGranted() {
+        for (String permission : getRequiredPermissions()) {
+            if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+                // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
+                // on devices with Android < P(9) checkSelfPermission(PERMISSION_FOREGROUND_SERVICE) can return PERMISSION_DENIED, but in fact it is GRANTED, so skip it
+                // https://developer.android.com/guide/components/services#Foreground
+                if (permission.equals(PERMISSION_FOREGROUND_SERVICE)) {
+                    continue;
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String[] getRequiredPermissions() {
+        String[] permissions;
+        try {
+            PackageInfo info = getPackageManager().getPackageInfo(getPackageName(), PackageManager.GET_PERMISSIONS);
+            String[] requestedPermissions = info.requestedPermissions;
+            if (requestedPermissions != null && requestedPermissions.length > 0) {
+                permissions = requestedPermissions;
+            } else {
+                permissions = new String[]{};
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            permissions = new String[]{};
+        }
+
+        return permissions;
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (allPermissionsGranted() && requestCode == PERMISSIONS_REQUEST_CODE) {
+            onPermissionsGranted();
+        }
+    }
+}

--- a/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
@@ -2,7 +2,6 @@ package com.mapbox.vision.examples;
 
 import android.graphics.Bitmap;
 import android.media.MediaMetadataRetriever;
-import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
 

--- a/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
@@ -5,7 +5,7 @@ import android.media.MediaMetadataRetriever;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
-import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.vision.VisionManager;
 import com.mapbox.vision.mobile.core.interfaces.VisionEventsListener;
 import com.mapbox.vision.mobile.core.models.AuthorizationStatus;
@@ -22,9 +22,9 @@ import com.mapbox.vision.mobile.core.models.world.WorldDescription;
 import com.mapbox.vision.video.videosource.VideoSource;
 import com.mapbox.vision.video.videosource.VideoSourceListener;
 import com.mapbox.vision.view.VisionView;
+
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
@@ -32,14 +32,15 @@ import java.util.concurrent.TimeUnit;
  * Example shows how Vision SDK can work with external video source. This can be some custom camera implementation or any
  * other source of frames - video, set of pictures, etc.
  */
-public class ExternalCameraSource extends AppCompatActivity {
+public class ExternalCameraSource extends BaseActivity {
 
     // Video file that will be processed.
-    private static final String VIDEO_FILE = "video.mp4";
+    private static final String PATH_TO_VIDEO_FILE = "path_to_video_file";
 
     private VideoSourceListener videoSourceListener;
     private VisionView visionView;
     private HandlerThread handlerThread = new HandlerThread("VideoDecode");
+    private boolean visionManagerWasInit = false;
 
     // VideoSource that will play the file.
     private VideoSource customVideoSource = new VideoSource() {
@@ -68,10 +69,12 @@ public class ExternalCameraSource extends AppCompatActivity {
     private VisionEventsListener visionEventsListener = new VisionEventsListener() {
 
         @Override
-        public void onAuthorizationStatusUpdated(@NotNull AuthorizationStatus authorizationStatus) {}
+        public void onAuthorizationStatusUpdated(@NotNull AuthorizationStatus authorizationStatus) {
+        }
 
         @Override
-        public void onFrameSegmentationUpdated(@NotNull FrameSegmentation frameSegmentation) {}
+        public void onFrameSegmentationUpdated(@NotNull FrameSegmentation frameSegmentation) {
+        }
 
         @Override
         public void onFrameDetectionsUpdated(@NotNull FrameDetections frameDetections) {
@@ -79,49 +82,80 @@ public class ExternalCameraSource extends AppCompatActivity {
         }
 
         @Override
-        public void onFrameSignClassificationsUpdated(@NotNull FrameSignClassifications frameSignClassifications) {}
+        public void onFrameSignClassificationsUpdated(@NotNull FrameSignClassifications frameSignClassifications) {
+        }
 
         @Override
-        public void onRoadDescriptionUpdated(@NotNull RoadDescription roadDescription) {}
+        public void onRoadDescriptionUpdated(@NotNull RoadDescription roadDescription) {
+        }
 
         @Override
-        public void onWorldDescriptionUpdated(@NotNull WorldDescription worldDescription) {}
+        public void onWorldDescriptionUpdated(@NotNull WorldDescription worldDescription) {
+        }
 
         @Override
-        public void onVehicleStateUpdated(@NotNull VehicleState vehicleState) {}
+        public void onVehicleStateUpdated(@NotNull VehicleState vehicleState) {
+        }
 
         @Override
-        public void onCameraUpdated(@NotNull Camera camera) {}
+        public void onCameraUpdated(@NotNull Camera camera) {
+        }
 
         @Override
-        public void onCountryUpdated(@NotNull Country country) {}
+        public void onCountryUpdated(@NotNull Country country) {
+        }
 
         @Override
-        public void onUpdateCompleted() {}
+        public void onUpdateCompleted() {
+        }
     };
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void initViews() {
         setContentView(R.layout.activity_main);
         visionView = findViewById(R.id.vision_view);
     }
 
     @Override
+    protected void onPermissionsGranted() {
+        startVisionManager();
+    }
+
+    @Override
     protected void onStart() {
         super.onStart();
-
-        VisionManager.create(customVideoSource);
-        VisionManager.start(visionEventsListener);
-        VisionManager.setVideoSourceListener(visionView);
+        startVisionManager();
     }
 
     @Override
     protected void onStop() {
         super.onStop();
+        stopVisionManager();
+    }
 
-        VisionManager.stop();
-        VisionManager.destroy();
+    private void startVisionManager() {
+        if (allPermissionsGranted() && !visionManagerWasInit) {
+            VisionManager.create(customVideoSource);
+            VisionManager.start(visionEventsListener);
+
+            VisionManager.setVideoSourceListener(visionView);
+
+            visionManagerWasInit = true;
+        }
+    }
+
+    private void stopVisionManager() {
+        if (visionManagerWasInit) {
+            VisionManager.stop();
+            VisionManager.destroy();
+
+            visionManagerWasInit = false;
+        }
     }
 
     /**
@@ -132,7 +166,7 @@ public class ExternalCameraSource extends AppCompatActivity {
         // It isn't the fastest approach to decode videos and you probably want some other method
         // if FPS is important (eg. MediaCodec).
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();
-        retriever.setDataSource(new File(getExternalFilesDir(""), VIDEO_FILE).getAbsolutePath());
+        retriever.setDataSource(PATH_TO_VIDEO_FILE);
 
         // Get video frame size.
         int frameWidth = Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH));

--- a/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
@@ -46,7 +46,7 @@ public class ExternalCameraSource extends BaseActivity {
 
         @Override
         public void attach(@NotNull VideoSourceListener videoSourceListener) {
-            // video source is attached, we can start decoding frames from video and feeding them to Vision SDK
+            // video source is attached, we can start decoding frames from video and feeding them to Vision SDK.
             ExternalCameraSource.this.videoSourceListener = videoSourceListener;
             handlerThread.start();
             new Handler(handlerThread.getLooper()).post(new Runnable() {
@@ -64,7 +64,7 @@ public class ExternalCameraSource extends BaseActivity {
         }
     };
 
-    // VideoSourceListener handles events from Vision SDK.
+    // VisionEventsListener handles events from Vision SDK on background thread.
     private VisionEventsListener visionEventsListener = new VisionEventsListener() {
 
         @Override
@@ -157,7 +157,7 @@ public class ExternalCameraSource extends BaseActivity {
      */
     private void startFileVideoSource() {
         // Use MediaMetadataRetriever to decode video.
-        // It isn't the fastest approach to decode videos and you probably want some other method
+        // It isn't the fastest approach to decode videos and you probably want some other method.
         // if FPS is important (eg. MediaCodec).
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();
         retriever.setDataSource(PATH_TO_VIDEO_FILE);

--- a/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/ExternalCameraSource.java
@@ -111,11 +111,6 @@ public class ExternalCameraSource extends BaseActivity {
     };
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
     protected void initViews() {
         setContentView(R.layout.activity_main);
         visionView = findViewById(R.id.vision_view);

--- a/Examples/src/main/java/com/mapbox/vision/examples/SafetyActivity.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/SafetyActivity.java
@@ -1,6 +1,5 @@
 package com.mapbox.vision.examples;
 
-import android.os.Bundle;
 import android.widget.Toast;
 
 import com.mapbox.vision.VisionManager;
@@ -64,12 +63,13 @@ public class SafetyActivity extends BaseActivity {
 
             // display toast with overspeed warning if our speed is greater than maximum allowed speed
             if (mySpeed > maxAllowedSpeed && maxAllowedSpeed > 0) {
-                Toast.makeText(
+                // all VisionListener callbacks are executed on a background thread. Need switch to a main thread
+                runOnUiThread(() -> Toast.makeText(
                         SafetyActivity.this,
                         "Overspeeding! Current speed : " + mySpeed +
                                 ", allowed speed : " + maxAllowedSpeed,
                         Toast.LENGTH_LONG
-                ).show();
+                ).show());
             }
         }
 

--- a/Examples/src/main/java/com/mapbox/vision/examples/SafetyActivity.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/SafetyActivity.java
@@ -98,11 +98,6 @@ public class SafetyActivity extends BaseActivity {
     };
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
     protected void initViews() {
         setContentView(R.layout.activity_main);
     }

--- a/Examples/src/main/java/com/mapbox/vision/examples/SafetyActivity.java
+++ b/Examples/src/main/java/com/mapbox/vision/examples/SafetyActivity.java
@@ -1,8 +1,8 @@
 package com.mapbox.vision.examples;
 
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
+
 import com.mapbox.vision.VisionManager;
 import com.mapbox.vision.mobile.core.interfaces.VisionEventsListener;
 import com.mapbox.vision.mobile.core.models.AuthorizationStatus;
@@ -18,35 +18,44 @@ import com.mapbox.vision.safety.VisionSafetyManager;
 import com.mapbox.vision.safety.core.VisionSafetyListener;
 import com.mapbox.vision.safety.core.models.CollisionObject;
 import com.mapbox.vision.safety.core.models.RoadRestrictions;
+import com.mapbox.vision.view.VisionView;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Example shows how overspeed can be detected using Vision and VisionSafety SDKs combined.
  */
-public class SafetyActivity extends AppCompatActivity {
+public class SafetyActivity extends BaseActivity {
 
     private Float maxAllowedSpeed = -1f;
+    private boolean visionManagerWasInit = false;
 
     // this listener handles events from Vision SDK
     private VisionEventsListener visionEventsListener = new VisionEventsListener() {
 
         @Override
-        public void onAuthorizationStatusUpdated(@NotNull AuthorizationStatus authorizationStatus) {}
+        public void onAuthorizationStatusUpdated(@NotNull AuthorizationStatus authorizationStatus) {
+        }
 
         @Override
-        public void onFrameSegmentationUpdated(@NotNull FrameSegmentation frameSegmentation) {}
+        public void onFrameSegmentationUpdated(@NotNull FrameSegmentation frameSegmentation) {
+        }
 
         @Override
-        public void onFrameDetectionsUpdated(@NotNull FrameDetections frameDetections) {}
+        public void onFrameDetectionsUpdated(@NotNull FrameDetections frameDetections) {
+        }
 
         @Override
-        public void onFrameSignClassificationsUpdated(@NotNull FrameSignClassifications frameSignClassifications) {}
+        public void onFrameSignClassificationsUpdated(@NotNull FrameSignClassifications frameSignClassifications) {
+        }
 
         @Override
-        public void onRoadDescriptionUpdated(@NotNull RoadDescription roadDescription) {}
+        public void onRoadDescriptionUpdated(@NotNull RoadDescription roadDescription) {
+        }
 
         @Override
-        public void onWorldDescriptionUpdated(@NotNull WorldDescription worldDescription) {}
+        public void onWorldDescriptionUpdated(@NotNull WorldDescription worldDescription) {
+        }
 
         @Override
         public void onVehicleStateUpdated(@NotNull VehicleState vehicleState) {
@@ -65,18 +74,22 @@ public class SafetyActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onCameraUpdated(@NotNull Camera camera) {}
+        public void onCameraUpdated(@NotNull Camera camera) {
+        }
 
         @Override
-        public void onCountryUpdated(@NotNull Country country) {}
+        public void onCountryUpdated(@NotNull Country country) {
+        }
 
         @Override
-        public void onUpdateCompleted() {}
+        public void onUpdateCompleted() {
+        }
     };
 
     private VisionSafetyListener visionSafetyListener = new VisionSafetyListener() {
         @Override
-        public void onCollisionsUpdated(@NotNull CollisionObject[] collisions) {}
+        public void onCollisionsUpdated(@NotNull CollisionObject[] collisions) {
+        }
 
         @Override
         public void onRoadRestrictionsUpdated(@NotNull RoadRestrictions roadRestrictions) {
@@ -87,26 +100,54 @@ public class SafetyActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void initViews() {
         setContentView(R.layout.activity_main);
+    }
+
+    @Override
+    protected void onPermissionsGranted() {
+        startVisionManager();
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-
-        VisionManager.create();
-        VisionManager.start(visionEventsListener);
-
-        VisionSafetyManager.create(VisionManager.INSTANCE, visionSafetyListener);
+        startVisionManager();
     }
 
     @Override
     protected void onStop() {
         super.onStop();
+        stopVisionManager();
+    }
 
-        VisionSafetyManager.destroy();
+    private void startVisionManager() {
+        if (allPermissionsGranted() && !visionManagerWasInit) {
+            // Create and start VisionManager.
+            VisionManager.create();
+            VisionManager.start(visionEventsListener);
 
-        VisionManager.stop();
-        VisionManager.destroy();
+            VisionView visionView = findViewById(R.id.vision_view);
+            VisionManager.setVideoSourceListener(visionView);
+
+            // Create and start VisionManager.
+            VisionSafetyManager.create(VisionManager.INSTANCE, visionSafetyListener);
+
+            visionManagerWasInit = true;
+        }
+    }
+
+    private void stopVisionManager() {
+        if (visionManagerWasInit) {
+            VisionSafetyManager.destroy();
+
+            VisionManager.stop();
+            VisionManager.destroy();
+
+            visionManagerWasInit = false;
+        }
     }
 }

--- a/Examples/src/main/kotlin/com/mapbox/vision/examples/ExternalCameraSourceKt.kt
+++ b/Examples/src/main/kotlin/com/mapbox/vision/examples/ExternalCameraSourceKt.kt
@@ -20,9 +20,9 @@ import com.mapbox.vision.mobile.core.models.road.RoadDescription
 import com.mapbox.vision.mobile.core.models.world.WorldDescription
 import com.mapbox.vision.video.videosource.VideoSource
 import com.mapbox.vision.video.videosource.VideoSourceListener
-import kotlinx.android.synthetic.main.activity_main.*
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
+import kotlinx.android.synthetic.main.activity_main.*
 
 /**
  * Example shows how Vision SDK can work with external video source. This can be some custom camera implementation or any
@@ -53,7 +53,7 @@ class ExternalCameraSourceKt : BaseActivity() {
         }
     }
 
-    // VideoSourceListener handles events from Vision SDK.
+    // VisionEventsListener handles events from Vision SDK on background thread.
     private val visionEventsListener = object : VisionEventsListener {
 
         override fun onAuthorizationStatusUpdated(authorizationStatus: AuthorizationStatus) {}
@@ -123,7 +123,7 @@ class ExternalCameraSourceKt : BaseActivity() {
      */
     private fun startFileVideoSource() {
         // Use MediaMetadataRetriever to decode video.
-        // It isn't the fastest approach to decode videos and you probably want some other method
+        // It isn't the fastest approach to decode videos and you probably want some other method.
         // if FPS is important (eg. MediaCodec).
         val retriever = MediaMetadataRetriever()
         retriever.setDataSource(PATH_TO_VIDEO_FILE)

--- a/Examples/src/main/kotlin/com/mapbox/vision/examples/ExternalCameraSourceKt.kt
+++ b/Examples/src/main/kotlin/com/mapbox/vision/examples/ExternalCameraSourceKt.kt
@@ -5,7 +5,6 @@ import android.media.MediaMetadataRetriever
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
-import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.vision.VisionManager
 import com.mapbox.vision.mobile.core.interfaces.VisionEventsListener
 import com.mapbox.vision.mobile.core.models.AuthorizationStatus
@@ -21,25 +20,24 @@ import com.mapbox.vision.mobile.core.models.road.RoadDescription
 import com.mapbox.vision.mobile.core.models.world.WorldDescription
 import com.mapbox.vision.video.videosource.VideoSource
 import com.mapbox.vision.video.videosource.VideoSourceListener
-import java.io.File
+import kotlinx.android.synthetic.main.activity_main.*
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
-import kotlinx.android.synthetic.main.activity_main.*
 
 /**
  * Example shows how Vision SDK can work with external video source. This can be some custom camera implementation or any
  * other source of frames - video, set of pictures, etc.
  */
-class ExternalCameraSourceKt : AppCompatActivity() {
+class ExternalCameraSourceKt : BaseActivity() {
 
     companion object {
         // Video file that will be processed.
-        private const val VIDEO_FILE = "video.mp4"
+        private const val PATH_TO_VIDEO_FILE = "path_to_video_file"
     }
 
     private var videoSourceListener: VideoSourceListener? = null
-
     private val handlerThread = HandlerThread("VideoDecode")
+    private var visionManagerWasInit = false
 
     // VideoSource that will play the file.
     private val customVideoSource = object : VideoSource {
@@ -81,22 +79,43 @@ class ExternalCameraSourceKt : AppCompatActivity() {
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+    }
+
+    override fun onPermissionsGranted() {
+        startVisionManager()
+    }
+
+    override fun initViews() {
         setContentView(R.layout.activity_main)
     }
 
     override fun onStart() {
         super.onStart()
-
-        VisionManager.create(customVideoSource)
-        VisionManager.start(visionEventsListener)
-        VisionManager.setVideoSourceListener(vision_view)
+        startVisionManager()
     }
 
     override fun onStop() {
         super.onStop()
+        stopVisionManager()
+    }
 
-        VisionManager.stop()
-        VisionManager.destroy()
+    private fun startVisionManager() {
+        if (allPermissionsGranted() && !visionManagerWasInit) {
+            VisionManager.create(customVideoSource)
+            VisionManager.start(visionEventsListener)
+            VisionManager.setVideoSourceListener(vision_view)
+
+            visionManagerWasInit = true
+        }
+    }
+
+    private fun stopVisionManager() {
+        if (visionManagerWasInit) {
+            VisionManager.stop()
+            VisionManager.destroy()
+
+            visionManagerWasInit = false
+        }
     }
 
     /**
@@ -107,17 +126,20 @@ class ExternalCameraSourceKt : AppCompatActivity() {
         // It isn't the fastest approach to decode videos and you probably want some other method
         // if FPS is important (eg. MediaCodec).
         val retriever = MediaMetadataRetriever()
-        retriever.setDataSource(File(getExternalFilesDir(""), VIDEO_FILE).absolutePath)
+        retriever.setDataSource(PATH_TO_VIDEO_FILE)
 
         // Get video frame size.
-        val frameWidth = Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH))
-        val frameHeight = Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT))
+        val frameWidth =
+            Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH))
+        val frameHeight =
+            Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT))
         val imageSize = ImageSize(frameWidth, frameHeight)
         // ByteBuffer to hold RGBA bytes.
         val rgbaByteBuffer = ByteBuffer.wrap(ByteArray(frameWidth * frameHeight * 4))
 
         // Get duration.
-        val duration = java.lang.Long.parseLong(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))
+        val duration =
+            java.lang.Long.parseLong(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION))
 
         try {
             // Get frames one by one with 1 second intervals.

--- a/Examples/src/main/kotlin/com/mapbox/vision/examples/SafetyActivityKt.kt
+++ b/Examples/src/main/kotlin/com/mapbox/vision/examples/SafetyActivityKt.kt
@@ -47,11 +47,14 @@ class SafetyActivityKt : BaseActivity() {
 
             // display toast with overspeed warning if our speed is greater than maximum allowed speed
             if (mySpeed > maxAllowedSpeed && maxAllowedSpeed > 0) {
-                Toast.makeText(
-                    this@SafetyActivityKt,
-                    "Overspeeding! Current speed : $mySpeed, allowed speed : $maxAllowedSpeed",
-                    Toast.LENGTH_LONG
-                ).show()
+                // all VisionListener callbacks are executed on a background thread. Need switch to a main thread
+                runOnUiThread {
+                    Toast.makeText(
+                        this@SafetyActivityKt,
+                        "Overspeeding! Current speed : $mySpeed, allowed speed : $maxAllowedSpeed",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
             }
         }
 

--- a/Examples/src/main/kotlin/com/mapbox/vision/examples/SafetyActivityKt.kt
+++ b/Examples/src/main/kotlin/com/mapbox/vision/examples/SafetyActivityKt.kt
@@ -1,8 +1,6 @@
 package com.mapbox.vision.examples
 
-import android.os.Bundle
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.vision.VisionManager
 import com.mapbox.vision.mobile.core.interfaces.VisionEventsListener
 import com.mapbox.vision.mobile.core.models.AuthorizationStatus
@@ -23,9 +21,10 @@ import kotlinx.android.synthetic.main.activity_main.*
 /**
  * Example shows how overspeed can be detected using Vision and VisionSafety SDKs combined.
  */
-class SafetyActivityKt : AppCompatActivity() {
+class SafetyActivityKt : BaseActivity() {
 
     private var maxAllowedSpeed: Float = -1f
+    private var visionManagerWasInit = false
 
     // this listener handles events from Vision SDK
     private val visionEventsListener = object : VisionEventsListener {
@@ -73,27 +72,44 @@ class SafetyActivityKt : AppCompatActivity() {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onPermissionsGranted() {
+        startVisionManager()
+    }
+
+    override fun initViews() {
         setContentView(R.layout.activity_main)
     }
 
     override fun onStart() {
         super.onStart()
-
-        VisionManager.create()
-        VisionManager.start(visionEventsListener)
-        VisionManager.setVideoSourceListener(vision_view)
-
-        VisionSafetyManager.create(VisionManager, visionSafetyListener)
+        startVisionManager()
     }
 
     override fun onStop() {
         super.onStop()
+        stopVisionManager()
+    }
 
-        VisionSafetyManager.destroy()
+    private fun startVisionManager() {
+        if (allPermissionsGranted() && !visionManagerWasInit) {
+            VisionManager.create()
+            VisionManager.start(visionEventsListener)
+            VisionManager.setVideoSourceListener(vision_view)
 
-        VisionManager.stop()
-        VisionManager.destroy()
+            VisionSafetyManager.create(VisionManager, visionSafetyListener)
+
+            visionManagerWasInit = true
+        }
+    }
+
+    private fun stopVisionManager() {
+        if (visionManagerWasInit) {
+            VisionSafetyManager.destroy()
+
+            VisionManager.stop()
+            VisionManager.destroy()
+
+            visionManagerWasInit = false
+        }
     }
 }

--- a/MapboxVision/src/main/java/com/mapbox/vision/VisionManager.kt
+++ b/MapboxVision/src/main/java/com/mapbox/vision/VisionManager.kt
@@ -192,7 +192,7 @@ object VisionManager : BaseVisionManager {
                 videoSource.setVideoRecorder(it)
             }
         } else {
-            VideoRecorder.EmptyImpl()
+            VideoRecorder.DummyVideoRecorder()
         }
 
         this.videoSource = videoSource

--- a/MapboxVision/src/main/java/com/mapbox/vision/VisionManager.kt
+++ b/MapboxVision/src/main/java/com/mapbox/vision/VisionManager.kt
@@ -63,7 +63,8 @@ import com.mapbox.vision.video.videosource.camera.VideoRecorder
 object VisionManager : BaseVisionManager {
 
     private const val MAPBOX_VISION_IDENTIFIER = "MapboxVision"
-    private const val MAPBOX_TELEMETRY_USER_AGENT = "$MAPBOX_VISION_IDENTIFIER/${BuildConfig.VERSION_NAME}"
+    private const val MAPBOX_TELEMETRY_USER_AGENT =
+        "$MAPBOX_VISION_IDENTIFIER/${BuildConfig.VERSION_NAME}"
 
     lateinit var application: Application
         private set
@@ -186,8 +187,13 @@ object VisionManager : BaseVisionManager {
         sensorsManager = SensorsManager.Impl(application)
         locationEngine = LocationEngine.Impl(application)
 
-        val videoRecorder = SurfaceVideoRecorder.MediaCodecPersistentSurfaceImpl(application)
-        (videoSource as? Camera2VideoSourceImpl)?.setVideoRecorder(videoRecorder)
+        val videoRecorder = if (videoSource is Camera2VideoSourceImpl) {
+            SurfaceVideoRecorder.MediaCodecPersistentSurfaceImpl(application).also {
+                videoSource.setVideoRecorder(it)
+            }
+        } else {
+            VideoRecorder.EmptyImpl()
+        }
 
         this.videoSource = videoSource
         this.videoRecorder = videoRecorder

--- a/MapboxVision/src/main/java/com/mapbox/vision/video/videosource/camera/SurfaceVideoRecorder.kt
+++ b/MapboxVision/src/main/java/com/mapbox/vision/video/videosource/camera/SurfaceVideoRecorder.kt
@@ -16,7 +16,7 @@ internal interface VideoRecorder {
     fun stopRecording()
     fun release()
 
-    class EmptyImpl : VideoRecorder {
+    class DummyVideoRecorder : VideoRecorder {
 
         override fun init(frameWidth: Int, frameHeight: Int, sensorOrientation: Int) {
             // do nothing

--- a/MapboxVision/src/main/java/com/mapbox/vision/video/videosource/camera/SurfaceVideoRecorder.kt
+++ b/MapboxVision/src/main/java/com/mapbox/vision/video/videosource/camera/SurfaceVideoRecorder.kt
@@ -15,6 +15,25 @@ internal interface VideoRecorder {
     fun startRecording(path: String)
     fun stopRecording()
     fun release()
+
+    class EmptyImpl : VideoRecorder {
+
+        override fun init(frameWidth: Int, frameHeight: Int, sensorOrientation: Int) {
+            // do nothing
+        }
+
+        override fun startRecording(path: String) {
+            // do nothing
+        }
+
+        override fun stopRecording() {
+            // do nothing
+        }
+
+        override fun release() {
+            // do nothing
+        }
+    }
 }
 
 internal interface SurfaceVideoRecorder : VideoRecorder {


### PR DESCRIPTION
Please check 3 java activities:
ArActivity
SafetyActivity
ExternalCameraSource

VisionManager is fixed to prevent crash when we pass NOT a `Camera2VideoSourceImpl` as `videoSource` into `onCreate`

closes #132 