### PR TITLE
Add github/stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,15 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 45
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: false
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - nostale
+# Label to use when marking an issue as stale
+staleLabel: staled
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Added initial stalebot config. All issues that are 45 days old and not closed and not with `nostale` label will be labeled as `staled` and commented on (but not closed, maybe changed later). More info on stalebot https://github.com/probot/stale. `nostale` label applied to all issued apart from `User feedback`.